### PR TITLE
process 값을 웹팩에서 사용하기

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,13 +1,11 @@
 const webpack = require('webpack');
 
 module.exports = (config, env) => {
-  console.log(config);
   const processENV = new webpack.DefinePlugin({
     'process.env': {
       'NODE_ENV': JSON.stringify('development'),
-      'test_env': JSON.stringify('ppp'),
+      'FLASHCARD_DEV_SECRET': JSON.stringify(process.env.FLASHCARD_DEV_SECRET),
     },
-    'process.FLASHCARD_DEV_SECRET': JSON.stringify(process.env.FLASHCARD_DEV_SECRET),
   })
   config.plugins.push(processENV);
   return config;

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,0 +1,14 @@
+const webpack = require('webpack');
+
+module.exports = (config, env) => {
+  console.log(config);
+  const processENV = new webpack.DefinePlugin({
+    'process.env': {
+      'NODE_ENV': JSON.stringify('development'),
+      'test_env': JSON.stringify('ppp'),
+    },
+    'process.FLASHCARD_DEV_SECRET': JSON.stringify(process.env.FLASHCARD_DEV_SECRET),
+  })
+  config.plugins.push(processENV);
+  return config;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13294,6 +13294,16 @@
         "prop-types": "15.6.1"
       }
     },
+    "react-app-rewired": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-1.5.0.tgz",
+      "integrity": "sha512-9yreFeLNivpznTUedl0GS7lWK+3aO2r6gs8nqOvQeublErRsbvIx6IF8l8rsMWEuO8Zve0jA7hycvLuXGyoG8w==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "dotenv": "4.0.0"
+      }
+    },
     "react-base16-styling": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.5.3.tgz",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "tui-editor": "^1.0.5"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-app-rewired start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
   "devDependencies": {
+    "react-app-rewired": "^1.5.0",
     "react-dev-utils": "^5.0.0",
     "redux-devtools": "^3.4.1",
     "redux-devtools-dock-monitor": "^1.1.3",

--- a/src/config/config.dev.js
+++ b/src/config/config.dev.js
@@ -2,7 +2,7 @@ const config = {
   githubAuth: {
     callback: 'http://localhost:3000/callback',
     clientId: 'b1497163e82bf1dfd9c1',
-    clientSecret: process.FLASHCARD_DEV_SECRET,
+    clientSecret: process.env.FLASHCARD_DEV_SECRET,
   },
 };
 

--- a/src/config/config.dev.js
+++ b/src/config/config.dev.js
@@ -2,6 +2,7 @@ const config = {
   githubAuth: {
     callback: 'http://localhost:3000/callback',
     clientId: 'b1497163e82bf1dfd9c1',
+    clientSecret: process.FLASHCARD_DEV_SECRET,
   },
 };
 

--- a/src/containers/signin.js
+++ b/src/containers/signin.js
@@ -8,8 +8,8 @@ import Popup from './../utils/popup';
 class Signin extends Component {
   constructor(props) {
     super(props);
-    const clistApp = 'b1497163e82bf1dfd9c1'
-    this.githubURL = `https://github.com/login/oauth/authorize?client_id=${clistApp}`
+    const clientId = Config.githubAuth.clientId;
+    this.githubURL = `https://github.com/login/oauth/authorize?client_id=${clientId}`
     this.state = {
       hasCodeParams: false,
     }
@@ -36,7 +36,6 @@ class Signin extends Component {
 
   render() {
     const { hasCodeParams } = this.state;
-    console.log(hasCodeParams);
     return(
       <div>
         {!hasCodeParams && <button onClick={this.requestGithub}>Login</button>}       


### PR DESCRIPTION
일단 처음에는 웹팩에서 사용하는 `process.env`가  노드처럼 시스템의 ` Environment Variables을 읽어오는 것인줄 알았는데, 그게 아니라 웹팩에서 따로 지정해주는 것이었다. 그래서 간단한 작업인줄 알았는데 처음에는 https://webpack.js.org/plugins/environment-plugin/ 이런게 왜 필요한지 몰랐는데, 알고보니 웹팩에서 따로 읽어서 처리해주는 것이었음.

따라서 어떠한 env값을 처리하고 싶으면 일단 웹팩에서 해당 env값을 읽어서 다시 리액트 앱에서 쓸 수 있도록 해줘야 하는데, create-react-app을 사용할 경우 eject를 사용해야 한다. 또 이러긴 싫어서 막 삽질하다가 config를 오버라이드 해주는 라이브러리를 만들어서 적용함.